### PR TITLE
Rename artifact to faim-imagej-stitching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,17 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.0.0-beta-2</version>
+		<version>29.0.0-beta-3</version>
 		<relativePath />
 	</parent>
 
 	<groupId>ch.fmi</groupId>
-	<artifactId>faim-ij2-visiview-processing</artifactId>
+	<artifactId>faim-imagej-stitching</artifactId>
 	<version>0.0.4-SNAPSHOT</version>
 
-	<name>Processing VisiView datasets</name>
-	<description>ImageJ plugins for processing VisiView datasets</description>
-	<url>https://github.com/fmi-basel/faim-ij2-visiview-processing</url>
+	<name>Stitching Utilities</name>
+	<description>ImageJ utilities and commands for stitching various datasets</description>
+	<url>https://github.com/fmi-basel/faim-imagej-stitching</url>
 	<inceptionYear>2019</inceptionYear>
 	<organization>
 		<name>Friedrich Miescher Institute for Biomedical Research (FMI), Basel</name>
@@ -60,18 +60,18 @@
 	</mailingLists>
 
 	<scm>
-		<connection>scm:git:git://github.com/fmi-basel/faim-ij2-visiview-processing</connection>
-		<developerConnection>scm:git:git@github.com:fmi-basel/faim-ij2-visiview-processing</developerConnection>
+		<connection>scm:git:git://github.com/fmi-basel/faim-imagej-stitching</connection>
+		<developerConnection>scm:git:git@github.com:fmi-basel/faim-imagej-stitching</developerConnection>
 		<tag>HEAD</tag>
-		<url>https://github.com/fmi-basel/faim-ij2-visiview-processing</url>
+		<url>https://github.com/fmi-basel/faim-imagej-stitching</url>
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/fmi-basel/faim-ij2-visiview-processing/issues</url>
+		<url>https://github.com/fmi-basel/faim-imagej-stitching/issues</url>
 	</issueManagement>
 	<ciManagement>
 		<system>Travis CI</system>
-		<url>https://travis-ci.com/fmi-basel/faim-ij2-visiview-processing</url>
+		<url>https://travis-ci.com/fmi-basel/faim-imagej-stitching</url>
 	</ciManagement>
 
 	<properties>
@@ -137,6 +137,7 @@
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
@@ -65,7 +65,7 @@ import ch.fmi.stitching.StitchingUtils;
 @Plugin(type = Command.class, headless = true,
 	menuPath = "FMI>VisiView Data>Stitch Dataset (default)",
 	initializer = "initializeDialog")
-public class VisiViewStitching extends DynamicCommand {
+public class StitchVisiviewDatasetCommand extends DynamicCommand {
 
 	private static final String QUICK = "Quick (do not compute overlap)";
 	private static final String VIA_MIP = "Compute overlap on maximum projection";

--- a/src/main/java/ch/fmi/stitching/visiview/VisiViewStitching.java
+++ b/src/main/java/ch/fmi/stitching/visiview/VisiViewStitching.java
@@ -28,7 +28,7 @@
  * #L%
  */
 
-package ch.fmi.visiview;
+package ch.fmi.stitching.visiview;
 
 import ij.ImagePlus;
 import ij.measure.Calibration;
@@ -52,7 +52,6 @@ import loci.formats.meta.IMetadata;
 import loci.plugins.BF;
 import loci.plugins.in.ImporterOptions;
 import mpicbg.models.InvertibleBoundable;
-import net.imagej.ImageJ;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.command.Command;
@@ -595,11 +594,4 @@ public class VisiViewStitching extends DynamicCommand {
 		return tileConfigFile.getAbsolutePath();
 	}
 
-	public static void main(final String... args) {
-		// create the ImageJ application context with all available services
-		final ImageJ ij = new ImageJ();
-		ij.ui().showUI();
-
-		ij.command().run(VisiViewStitching.class, true);
-	}
 }

--- a/src/test/java/ch/fmi/visiview/Main.java
+++ b/src/test/java/ch/fmi/visiview/Main.java
@@ -1,0 +1,18 @@
+
+package ch.fmi.visiview;
+
+import net.imagej.ImageJ;
+
+/**
+ * Main class for interactive testing and debugging
+ *
+ * @author Jan Eglinger
+ */
+public class Main {
+
+	public static void main(final String... args) {
+		// create the ImageJ application context with all available services
+		final ImageJ ij = new ImageJ();
+		ij.ui().showUI();
+	}
+}


### PR DESCRIPTION
- remove `main()` method from VisiViewStitching
- add `Main` class in test scope for debugging
- set `net.imagej:imagej` dependency to `test` scope

Closes #5.