### PR TITLE
Add more use cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>ome</groupId>
 			<artifactId>bio-formats_plugins</artifactId>
 			<exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<scifio.version>0.37.3</scifio.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/ch/fmi/stitching/StitchingUtils.java
+++ b/src/main/java/ch/fmi/stitching/StitchingUtils.java
@@ -209,7 +209,7 @@ public class StitchingUtils {
 	 * @param xSize Width of a single tile
 	 * @param ySize Height of a single tile
 	 */
-	public static void drawPositions(BufferedImage image, ArrayList<float[]> pixelPositions, long xSize, long ySize)
+	public static void drawPositions(BufferedImage image, List<float[]> pixelPositions, long xSize, long ySize)
 	{
 		Float xMin = Float.POSITIVE_INFINITY;
 		Float yMin = Float.POSITIVE_INFINITY;

--- a/src/main/java/ch/fmi/stitching/visiview/StitchBrokenDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchBrokenDatasetCommand.java
@@ -1,0 +1,214 @@
+
+package ch.fmi.stitching.visiview;
+
+import static ch.fmi.stitching.visiview.UIConstants.COMPUTE_FULL;
+import static ch.fmi.stitching.visiview.UIConstants.COMPUTE_NONE;
+import static ch.fmi.stitching.visiview.UIConstants.COMPUTE_VIA_MIP;
+import static ch.fmi.stitching.visiview.UIConstants.LAYOUT_HEIGHT;
+import static ch.fmi.stitching.visiview.UIConstants.LAYOUT_WIDTH;
+import static ch.fmi.stitching.visiview.UIConstants.OUTPUT_FULL;
+import static ch.fmi.stitching.visiview.UIConstants.OUTPUT_MIP;
+import static ch.fmi.stitching.visiview.UIConstants.OUTPUT_TXT;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.scijava.ItemIO;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import ch.fmi.stitching.StitchingUtils;
+import ij.ImagePlus;
+import mpicbg.models.InvertibleBoundable;
+
+@Plugin(type = Command.class, headless = true,
+	menuPath = "FMI>VisiView Data>Stitch Unreadable VisiView Dataset")
+public class StitchBrokenDatasetCommand extends DynamicCommand {
+
+	@Parameter(label = "Input dataset file (nd)", style = "extensions:nd",
+		callback = "ndFileChanged", persist = false)
+	private File ndFile;
+
+	@Parameter(label = " ", visibility = ItemVisibility.MESSAGE, persist = false,
+		required = false)
+	private String ndMessage = " ";
+
+	@Parameter(label = "Stage position file (stg)", style = "extensions:stg",
+		callback = "stgFileChanged", required = false, persist = false)
+	private File stgFile = null;
+
+	@Parameter(label = " ", visibility = ItemVisibility.MESSAGE, persist = false,
+		required = false)
+	private String stgMessage = " ";
+
+	@Parameter(label = "Overlap computation mode", style = "radioButtonVertical", //
+		choices = { COMPUTE_NONE, COMPUTE_VIA_MIP, COMPUTE_FULL }, required = false)
+	private String stitchingMode = COMPUTE_NONE;
+
+	@Parameter(label = "Output", style = "radioButtonVertical", //
+			choices = { OUTPUT_MIP, OUTPUT_FULL }, required = false)
+		private String outputMode = OUTPUT_FULL;
+
+	@Parameter(label = "Channels (e.g. 2-4 or 1,4 - leave empty for all)", required = false)
+	private String channelSelection = "";
+
+	@Parameter(label = "Pixel spacing (x)", callback = "xSpacingChanged")
+	private Double xCal;
+
+	@Parameter(label = "Pixel spacing (y)", callback = "ySpacingChanged")
+	private Double yCal;
+
+	@Parameter(label = "Pixel spacing (z)")
+	private Double zCal;
+
+	@Parameter(required = false, persist = false)
+	private BufferedImage layout = new BufferedImage(LAYOUT_WIDTH, LAYOUT_HEIGHT,
+		BufferedImage.TYPE_INT_RGB);
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private ImagePlus fused;
+
+	@Parameter
+	private LogService logService;
+
+	private boolean ndFileChanged;
+	private boolean stgFileChanged;
+	private List<String> positionNames;
+	private List<List<File>> stkFileList; // List of stk files in sets of positions
+	private ArrayList<ImagePlus> images; // ArrayList required by stitching API
+	private List<float[]> pixelPositions;
+	private long xSize = 100;
+	private long ySize = 100;
+	private boolean stgRequired;
+
+	private boolean validDatasetInfo;
+
+	private int nChannels;
+
+	private int nFrames;
+
+	@Override
+	public void run() {
+		if (validDatasetInfo) {
+			logService.info("now stitching...");
+			logService.debug(stkFileList);
+
+			images = new ArrayList<>();
+			for (List<File> positionList : stkFileList) {
+				images.add(VisiviewUtils.loadPositionStack(positionList, nChannels, nFrames));
+			}
+
+			// TODO handle overlap computation via MIP
+			// TODO support output option MIP
+			ArrayList<InvertibleBoundable> models = StitchingUtils.computeStitching(images, pixelPositions, 3, !stitchingMode.equals(COMPUTE_NONE));
+			fused = StitchingUtils.fuseTiles(images, models, 3);
+			// TODO set output calibration and hyperstack dimensions
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private void ndFileChanged() {
+		ndFileChanged = true;
+		if (!stgFileChanged) autoupdateStgFileParameter();
+		updateNdFileInfo();
+	}
+
+	@SuppressWarnings("unused")
+	private void stgFileChanged() {
+		stgFileChanged = true;
+		if (!ndFileChanged) autoupdateNdFileParameter();
+		updateStgFileInfo();
+	}
+
+	private void autoupdateStgFileParameter() {
+		if (ndFile == null || !ndFile.exists()) {
+			ndMessage = "<html><p style=\"color:red\">Not a valid nd file.</p></html>";
+			return;
+		}
+		stgFile = VisiviewUtils.getMatchingStgForNd(ndFile);
+		if (stgFile == null) {
+			stgMessage =
+				"<html><p style=\"color:red\">No matching stg file found.</p></html>";
+			return;
+		}
+		stgMessage =
+			"<html><p style=\"color:green\">The stg file path was updated automatically.</p></html>";
+		updateStgFileInfo();
+	}
+
+	private void autoupdateNdFileParameter() {
+		if (stgFile == null || !stgFile.exists()) {
+			stgMessage = "<html><p style=\"color:red\">Not a valid stg file.</p></html>";
+			return;
+		}
+		ndFile = VisiviewUtils.getMatchingNdForStg(stgFile);
+		if (ndFile == null) {
+			ndMessage = "<html><p style=\"color:red\">No matching nd file found.</p></html>";
+			return;
+		}
+		ndMessage =
+			"<html><p style=\"color:green\">The nd file path was updated automatically.</p></html>";
+		updateNdFileInfo();
+	}
+
+	private void updateNdFileInfo() {
+		// parse nd file
+		try {
+			Map<String, String> datasetMap = VisiviewUtils.parseNdFile(ndFile);
+			nChannels = VisiviewUtils.getNChannels(datasetMap);
+			nFrames = VisiviewUtils.getNFrames(datasetMap);
+			// populate file list
+			stkFileList = VisiviewUtils.getCompanionFiles(ndFile, datasetMap);
+
+			// populate position names
+			positionNames = VisiviewUtils.getPositionNames(datasetMap);
+			stgRequired = !VisiviewUtils.positionsMatchGridPattern(positionNames);
+			// populate pixel positions (if available from grid)
+			if (!stgRequired) {
+				logService.debug("Position names match Row#_Col# pattern");
+				pixelPositions = VisiviewUtils.positionsFromNames(positionNames, xSize, ySize);
+				StitchingUtils.drawPositions(layout, pixelPositions, xSize, ySize);
+				stgMessage =
+					"<html><font style=\"color:green\">No stage position file required.</font></html>";
+			}
+			ndMessage = "<html>This dataset contains <font style=\"color:green\">" +
+					positionNames.size() + "</font> series.</html>";
+			validDatasetInfo = true;
+		}
+		catch (IOException exc) {
+			logService.debug("Error parsing nd file", exc);
+			ndMessage = "Error parsing nd file";
+		}
+	}
+
+	private void updateStgFileInfo() {
+		try {
+			pixelPositions = VisiviewUtils.positionsFromStgFile(stgFile, xCal, yCal);
+			// TODO get xSize and ySize from first tile?
+			StitchingUtils.drawPositions(layout, pixelPositions, xSize, ySize);
+		}
+		catch (IOException exc) {
+			stgMessage = "Error parsing stg file";
+			logService.debug("Error parsing stg file", exc);
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private void xSpacingChanged() {
+		yCal = xCal;
+		ySpacingChanged();
+	}
+
+	private void ySpacingChanged() {
+		updateStgFileInfo();
+	}
+
+}

--- a/src/main/java/ch/fmi/stitching/visiview/StitchMultipleDatasetsCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchMultipleDatasetsCommand.java
@@ -1,0 +1,104 @@
+package ch.fmi.stitching.visiview;
+
+import io.scif.FilePattern;
+import io.scif.services.FilePatternService;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.scijava.ItemIO;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import ch.fmi.stitching.StitchingUtils;
+import ij.ImagePlus;
+import loci.formats.FormatException;
+import loci.plugins.BF;
+import mpicbg.models.InvertibleBoundable;
+
+@Plugin(type = Command.class, headless = true,
+	menuPath = "FMI>VisiView Data>Stitch Multiple Datasets as Tiles")
+public class StitchMultipleDatasetsCommand extends DynamicCommand {
+
+	@Parameter(label = "Representative file", style = "open", callback = "fileChanged", persist = false)
+	private File inputFile;
+	// callback: list files with same extension, detect similarities, suggest series number pattern
+
+	@Parameter(label = "File name pattern", callback = "patternChanged", persist = false)
+	private String pattern;
+
+	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false, required = false)
+	private String message = "Please select a file.";
+
+	@Parameter(label = "Save RAM at the cost of speed", required = false)
+	private boolean saveRAM = true;
+
+	@Parameter
+	private FilePatternService filePatternService;
+
+	@Parameter
+	private LogService logService;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private ImagePlus fused;
+
+	private List<File> fileList;
+
+	@Override
+	public void run() {
+		// list all files matching pattern in parent folder
+		ArrayList<ImagePlus> imageList = new ArrayList<>();
+		int dimensionality = 2;
+		// open all images
+		try {
+			for (File file : fileList) {
+				ImagePlus[] imps = BF.openImagePlus(file.getAbsolutePath());
+				if (imps[0].getNSlices() > 1) dimensionality = 3;
+				imageList.add(imps[0]);
+			}
+		}
+		catch (FormatException exc) {
+			// TODO Auto-generated catch block
+			exc.printStackTrace();
+		}
+		catch (IOException exc) {
+			// TODO Auto-generated catch block
+			exc.printStackTrace();
+		}
+
+		// Compute stitching
+		float[] initialPosition = {0, 0, 0};
+		ArrayList<InvertibleBoundable> models = StitchingUtils.computeStitching(imageList, Collections.nCopies(imageList.size(), initialPosition), dimensionality, true, saveRAM);
+
+		// Fuse images
+		fused = StitchingUtils.fuseTiles(imageList, models, dimensionality);
+	}
+
+	// -- Callback methods --
+
+	@SuppressWarnings("unused")
+	private void fileChanged() {
+		pattern = filePatternService.findPattern(inputFile);
+		patternChanged();
+	}
+
+	private void patternChanged() {
+		if (inputFile == null) {
+			return;
+		}
+		FilePattern filePattern = new FilePattern(getContext(), pattern);
+		fileList = Arrays.stream(filePattern.getFiles()).map(path -> new File(path)).filter(f -> f.exists()).collect(Collectors.toList());
+		// update file list
+		// update message
+		message = fileList.size() + " file(s) matching pattern.";
+	}
+}

--- a/src/main/java/ch/fmi/stitching/visiview/UIConstants.java
+++ b/src/main/java/ch/fmi/stitching/visiview/UIConstants.java
@@ -1,0 +1,21 @@
+
+package ch.fmi.stitching.visiview;
+
+public class UIConstants {
+
+	protected static final String COMPUTE_NONE = "Quick (do not compute overlap)";
+	protected static final String COMPUTE_VIA_MIP = "Compute overlap on maximum projection";
+	protected static final String COMPUTE_FULL = "Compute overlap on full volume";
+
+	protected static final String OUTPUT_TXT = "Coordinates text file only";
+	protected static final String OUTPUT_MIP = "Maximum projection only";
+	protected static final String OUTPUT_FULL = "Full volume output";
+
+	protected static final int LAYOUT_WIDTH = 256;
+	protected static final int LAYOUT_HEIGHT = 256;
+
+	private UIConstants() {
+		// prevent instantiation of static utility class
+	}
+
+}

--- a/src/main/java/ch/fmi/stitching/visiview/VisiviewUtils.java
+++ b/src/main/java/ch/fmi/stitching/visiview/VisiviewUtils.java
@@ -1,0 +1,206 @@
+package ch.fmi.stitching.visiview;
+
+import com.opencsv.CSVReader;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import ij.IJ;
+import ij.ImagePlus;
+import ij.plugin.Concatenator;
+import ij.plugin.HyperStackConverter;
+
+public class VisiviewUtils {
+
+	public static final float VISIVIEW_OVERLAP_FACTOR = 0.1f;
+
+	private static final long STG_FIRST_POSITION_LINE_INDEX = 4;
+	private static final Pattern ND_FILE_PATTERN = Pattern.compile("(.*_)\\d\\.nd");
+	private static final Pattern STG_FILE_PATTERN = Pattern.compile("(.*_)\\.stg");
+	private static final Pattern GRID_POSITION_PATTERN = Pattern.compile(".*Row(\\d+)_Col(\\d+).*");
+
+	private static final String DO_WAVE = "DoWave";
+	private static final String DO_STAGE = "DoStage";
+	private static final String DO_TIMELAPSE = "DoTimelapse";
+	private static final String DO_Z_SERIES = "DoZSeries";
+	private static final String WAVE_DO_Z_PREFIX = "WaveDoZ";
+	private static final String WAVE_NAME_PREFIX = "WaveName";
+	private static final String N_WAVELENGTHS = "NWavelengths";
+	private static final String N_STAGE_POSITIONS = "NStagePositions";
+	private static final String N_TIMEPOINTS = "NTimePoints";
+
+	private VisiviewUtils() {
+		// prevent instantiation of static utility class
+	}
+
+	public static File getMatchingStgForNd(File ndFile) {
+		Matcher m = ND_FILE_PATTERN.matcher(ndFile.getName());
+		if (m.matches()) {
+			File stgFileCandidate = new File(ndFile.getParent(), m.group(1) + ".stg");
+			if (!stgFileCandidate.exists()) {
+				return null;
+			}
+			return stgFileCandidate;
+		}
+		return null;
+	}
+
+	public static File getMatchingNdForStg(File stgFile) {
+		Matcher m = STG_FILE_PATTERN.matcher(stgFile.getName());
+		if (m.matches()) {
+			File ndFileCandidate = new File(stgFile.getParent(), m.group(1) + "1.nd");
+			// TODO test more numbers, i.e. 2.nd, 3.nd, 4.nd, ...
+			if (!ndFileCandidate.exists()) {
+				return null;
+			}
+			return ndFileCandidate;
+		}
+		return null;
+	}
+
+	/**
+	 * Provide a list of companion (stk) files, given an nd file path and the
+	 * corresponding metadata map. The returned list is a nested list, containing
+	 * the positions in the outer list, and both wavelengths and timepoints
+	 * (CT-ordered) in the inner list.
+	 * 
+	 * @param ndFile
+	 * @param datasetInfo
+	 * @return List of positions containing a list of all stk files (all
+	 *         wavelengths and all time points) per position.
+	 */
+	public static List<List<File>> getCompanionFiles(File ndFile,
+		Map<String, String> datasetInfo)
+	{
+		List<List<File>> stkList = new ArrayList<>();
+		File parent = ndFile.getParentFile();
+		// prefix
+		String ndFileName = ndFile.getName();
+		String prefix = ndFileName.substring(0, ndFileName.lastIndexOf("."));
+		// channel suffix
+		int nWavelengths = getNdParameter(datasetInfo, DO_WAVE, N_WAVELENGTHS);
+		// stage positions
+		int nStagePositions = getNdParameter(datasetInfo, DO_STAGE, N_STAGE_POSITIONS);
+		// time points
+		int nTimePoints = getNdParameter(datasetInfo, DO_TIMELAPSE, N_TIMEPOINTS);
+
+		for (int s = 1; s <= nStagePositions; s++) {
+			List<File> positionStk = new ArrayList<>();
+			for (int t = 1; t <= nTimePoints; t++) {
+				for (int w = 1; w <= nWavelengths; w++) {
+					String filename = prefix;
+					filename += nWavelengths > 1 ? "_w" + w + datasetInfo.get(WAVE_NAME_PREFIX + w).trim() : "";
+					filename += nStagePositions > 1 ? "_s" + s : "";
+					filename += nTimePoints > 1 ? "_t" + t : "";
+					boolean isStack = getNdBoolean(datasetInfo, DO_Z_SERIES) &&
+							(nWavelengths == 1 || getNdBoolean(datasetInfo, WAVE_DO_Z_PREFIX + w));
+					filename += isStack ? ".stk" : ".tif";
+					positionStk.add(new File(parent, filename));
+					//System.out.println(filename);
+				}
+			}
+			stkList.add(positionStk);
+		}
+		// TODO respect WaveInFileName? (for multi-channel only; this is true for all datasets known at FMI)
+		return stkList;
+	}
+
+	public static ImagePlus loadPositionStack(List<File> fileList, int nChannels, int nTimepoints) {
+		ImagePlus[] imageArray = new ImagePlus[nChannels * nTimepoints];
+		int i=0;
+		for (File file : fileList) {
+			imageArray[i++] = IJ.openImage(file.getAbsolutePath());
+		}
+		ImagePlus concatenatedStack = new Concatenator().concatenate(imageArray, false);
+		new HyperStackConverter().shuffle(concatenatedStack, HyperStackConverter.ZCT);
+		return concatenatedStack;
+	}
+
+	public static int getNChannels(Map<String, String> info) {
+		return getNdParameter(info, DO_WAVE, N_WAVELENGTHS);
+	}
+
+	public static int getNFrames(Map<String, String> info) {
+		return getNdParameter(info, DO_TIMELAPSE, N_TIMEPOINTS);
+	}
+
+	private static boolean getNdBoolean(Map<String, String> info, String flag) {
+		return Boolean.parseBoolean(info.get(flag).trim());
+	}
+
+	private static int getNdParameter(Map<String, String> info, String doString, String nString) {
+		System.out.println(doString);
+		if (!Boolean.parseBoolean(info.get(doString).trim()))
+			return 1;
+		return Integer.parseInt(info.get(nString).trim());
+	}
+
+	public static List<String> getPositionNames(Map<String, String> datasetInfo) {
+		int nSeries = Integer.parseInt(datasetInfo.get("NStagePositions").trim());
+		ArrayList<String> positionNames = new ArrayList<>();
+		for (int i = 1; i <= nSeries; i++) {
+			positionNames.add(datasetInfo.get("Stage" + i).trim());
+		}
+		return positionNames;
+	}
+
+	public static Map<String, String> parseNdFile(File ndFile) throws IOException {
+		try (FileReader fileReader = new FileReader(ndFile);
+				CSVReader csvReader = new CSVReader(fileReader))
+		{
+			return csvReader.readAll().stream().filter(arr -> arr.length > 1).collect(
+				Collectors.toMap(arr -> arr[0], arr -> arr[1]));
+		}
+		//return Files.lines(ndFile.toPath()).map(line -> parseNdLine(line)).filter(
+		//	Objects::nonNull).collect(Collectors.toMap(arr -> arr[0], arr -> arr[1]));
+	}
+
+	public static List<float[]> positionsFromStgFile(File stgFile, double xCal,
+		double yCal) throws IOException
+	{
+		// NB: the positions usually start at line index 4
+		// This won't work for stg files containing "categories"
+		// See https://mdc.custhelp.com/app/answers/detail/a_id/20065/kw/stg
+		return Files.lines(stgFile.toPath()).skip(STG_FIRST_POSITION_LINE_INDEX)
+			.map(line -> parseLine(line, xCal, yCal)).collect(Collectors.toList());
+	}
+
+	public static List<float[]> positionsFromNames(List<String> positionNames, long xSize, long ySize) {
+		// get pixelPositions from positionNames, or null if not applicable
+		return positionNames.stream().map(name -> parseGridPosition(name, xSize, ySize)).collect(Collectors.toList());
+	}
+
+	public static boolean positionsMatchGridPattern(List<String> positions) {
+		for (String p : positions) {
+			if (!GRID_POSITION_PATTERN.matcher(p).matches()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static float[] parseGridPosition(String name, long xSize, long ySize) {
+		Matcher m = GRID_POSITION_PATTERN.matcher(name);
+		if (m.matches()) {
+			return new float[] {
+				Integer.parseInt(m.group(2)) * xSize * (1 - VISIVIEW_OVERLAP_FACTOR),
+				Integer.parseInt(m.group(1)) * ySize * (1 - VISIVIEW_OVERLAP_FACTOR)				
+			};
+		}
+		return null;
+	}
+
+	private static float[] parseLine(String line, double xCal, double yCal) {
+		String[] tokens = line.split(",");
+		return new float[] { (float) (Float.parseFloat(tokens[1]) / xCal),
+			(float) (Float.parseFloat(tokens[2]) / yCal) };
+	}
+}

--- a/src/test/java/ch/fmi/visiview/VisiviewUtilsTest.java
+++ b/src/test/java/ch/fmi/visiview/VisiviewUtilsTest.java
@@ -1,0 +1,48 @@
+package ch.fmi.visiview;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.fmi.stitching.visiview.VisiviewUtils;
+
+
+public class VisiviewUtilsTest {
+
+	@Before
+	public void setUp() {
+		
+	}
+
+	@After
+	public void tearDown() {
+		
+	}
+
+	@Test
+	public void testGetCompanionFiles() {
+		File ndFile = new File("fake/path/test_experiment.nd");
+		Map<String, String> datasetInfo = new HashMap<String, String>() {{
+			put("DoWave", " FALSE");
+			put("DoStage", " TRUE");
+			put("NStagePositions", " 5");
+			put("DoTimelapse", " FALSE");
+			put("DoZSeries", " TRUE");
+		}};
+		List<List<File>> fileList = VisiviewUtils.getCompanionFiles(ndFile, datasetInfo);
+		System.err.println(fileList);
+
+		File testFile1 = new File("fake/path/test_experiment_s5.stk");
+		assertTrue(fileList.stream().flatMap(Collection::stream).collect(Collectors
+			.toList()).contains(testFile1));
+	}
+}


### PR DESCRIPTION
This pull request adds a static utility class:

* `VisiviewUtils`, containing methods specific to handling of nd/stk files, 

and two new commands:

* `StitchMultipleDatasetsCommand` (*FMI > VisiView Data > Stitch Multiple Dataset as Tiles*)
  This command allows stitching of datasets acquired independently, with manually moving the stage between the tile acquisitions.

* `StitchBrokenDatasetCommand` (*FMI > VisiView Data > Stitch Unreadable VisiView Dataset*)
  This command allows stitching of datasets where bio-formats fails to read the `nd` and/or `stk` files, by using the ImageJ 1.x TIFF reader to load pixel data.
