### PR TITLE
Be more careful about null values

### DIFF
--- a/src/main/java/ch/fmi/stitching/StitchingUtils.java
+++ b/src/main/java/ch/fmi/stitching/StitchingUtils.java
@@ -211,6 +211,8 @@ public class StitchingUtils {
 	 */
 	public static void drawPositions(BufferedImage image, List<float[]> pixelPositions, long xSize, long ySize)
 	{
+		if (image == null) return;
+
 		Float xMin = Float.POSITIVE_INFINITY;
 		Float yMin = Float.POSITIVE_INFINITY;
 		Float xMax = Float.NEGATIVE_INFINITY;

--- a/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
@@ -157,7 +157,7 @@ public class StitchVisiviewDatasetCommand extends DynamicCommand {
 		logService.debug("Now running...");
 
 		// Ensure valid input parameters
-		if (!doOverrideCalibration && !validDatasetInfo) updateNdFileInfo();
+		if (!doOverrideCalibration || !validDatasetInfo) updateNdFileInfo();
 		if (stgRequired && stgFile != null && stgFile.exists()) {
 			updateStgFileInfo();
 		} else if (stgRequired) {
@@ -325,7 +325,7 @@ public class StitchVisiviewDatasetCommand extends DynamicCommand {
 	private void ndFileChanged() {
 		ndFileChanged = true;
 		updateNdFileInfo();
-		if (!stgFileChanged) autoupdateStgFileParameter();
+		if (stgRequired && !stgFileChanged) autoupdateStgFileParameter();
 	}
 
 	@SuppressWarnings("unused")
@@ -405,7 +405,8 @@ public class StitchVisiviewDatasetCommand extends DynamicCommand {
 
 		xCal = (Double) omeMeta.getPixelsPhysicalSizeX(0).value();
 		yCal = (Double) omeMeta.getPixelsPhysicalSizeY(0).value();
-		if (zSize > 1 && nSeries > 1) zCal = (Double) omeMeta.getPixelsPhysicalSizeZ(0).value();
+		if (zSize > 1 && nSeries > 1 && omeMeta.getPixelsPhysicalSizeZ(0) != null)
+			zCal = (Double) omeMeta.getPixelsPhysicalSizeZ(0).value();
 
 		positionNames = new ArrayList<>();
 		for (int i = 0; i < nSeries; i++) {


### PR DESCRIPTION
When calling via `CommandService`, some fields can be `null`. Also in case the metadata were read incorrectly.