### PR TITLE
MIP Stitching with Illumination Field Correction on DAPI

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,25 +1,339 @@
-Copyright (c) 2019 - 2020, Friedrich Miescher Institute for Biomedical
-			Research, Basel
-All rights reserved.
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+			    Preamble
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 	</organization>
 	<licenses>
 		<license>
-			<name>BSD 2-Clause License</name>
-			<url>https://opensource.org/licenses/BSD-2-Clause</url>
+			<name>GNU General Public License v2+</name>
+			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -76,14 +76,13 @@
 
 	<properties>
 		<package-name>ch.fmi</package-name>
-		<license.licenseName>bsd_2</license.licenseName>
+		<license.licenseName>gpl_v2</license.licenseName>
 		<license.copyrightOwners>Friedrich Miescher Institute for Biomedical
 			Research, Basel</license.copyrightOwners>
 		<license.excludes>**/resources/scripts/**</license.excludes>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-
 		<scifio.version>0.37.3</scifio.version>
 	</properties>
 
@@ -139,6 +138,11 @@
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-legacy</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm-gpl</artifactId>
 		</dependency>
 
 		<!-- for running the main method -->

--- a/src/main/java/ch/fmi/stitching/StitchingUtils.java
+++ b/src/main/java/ch/fmi/stitching/StitchingUtils.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/main/java/ch/fmi/stitching/visiview/StitchBrokenDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchBrokenDatasetCommand.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/main/java/ch/fmi/stitching/visiview/StitchMultipleDatasetsCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchMultipleDatasetsCommand.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 package ch.fmi.stitching.visiview;

--- a/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewDatasetCommand.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewIlluminationCorrectedDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewIlluminationCorrectedDatasetCommand.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewIlluminationCorrectedDatasetCommand.java
+++ b/src/main/java/ch/fmi/stitching/visiview/StitchVisiviewIlluminationCorrectedDatasetCommand.java
@@ -1,0 +1,636 @@
+/*-
+ * #%L
+ * ImageJ utilities and commands for stitching various datasets
+ * %%
+ * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * 			Research, Basel
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ch.fmi.stitching.visiview;
+
+import ch.fmi.stitching.StitchingUtils;
+import ij.ImagePlus;
+import ij.measure.Calibration;
+import ij.plugin.Duplicator;
+import ij.plugin.ZProjector;
+import io.scif.SCIFIO;
+import io.scif.services.FormatService;
+import loci.formats.FormatException;
+import loci.formats.ImageReader;
+import loci.formats.MetadataTools;
+import loci.formats.meta.IMetadata;
+import loci.plugins.BF;
+import loci.plugins.in.ImporterOptions;
+import mpicbg.models.InvertibleBoundable;
+import net.imagej.ImgPlus;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.algorithm.localization.*;
+import net.imglib2.algorithm.stats.ComputeMinMax;
+import net.imglib2.img.ImagePlusAdapter;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.jetbrains.annotations.Nullable;
+import org.scijava.ItemIO;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+import static ch.fmi.stitching.visiview.UIConstants.*;
+
+@Plugin(type = Command.class, headless = true,
+	menuPath = "FMI>VisiView Data>Stitch Dataset with DAPI Illumination Correction",
+	initializer = "initializeDialog")
+public class StitchVisiviewIlluminationCorrectedDatasetCommand extends DynamicCommand {
+
+	@Parameter(label = "Input dataset file (nd)", style = "extensions:nd",
+		callback = "ndFileChanged", persist = false)
+	private File ndFile;
+
+	@Parameter(label = " ", visibility = ItemVisibility.MESSAGE, persist = false,
+		required = false)
+	private String ndMessage = " ";
+
+	@Parameter(label = "Stage position file (stg)", style = "extensions:stg",
+		callback = "stgFileChanged", required = false, persist = false)
+	private File stgFile = null;
+
+	@Parameter(label = " ", visibility = ItemVisibility.MESSAGE, persist = false,
+		required = false)
+	private String stgMessage = " ";
+
+	@Parameter(label = "Overlap computation mode", style = "radioButtonVertical", //
+		choices = { COMPUTE_NONE, COMPUTE_VIA_MIP }, required = false)
+	private String stitchingMode = COMPUTE_NONE;
+
+	@Parameter(label = "Output", style = "radioButtonVertical", //
+		choices = { OUTPUT_TXT, OUTPUT_MIP }, required = false)
+	private String outputMode = OUTPUT_MIP;
+
+	@Parameter(label = "Save RAM at the cost of speed", required = false)
+	private boolean saveRAM = false;
+
+	@Parameter(label = "Override calibration metadata with provided values",
+		required = false)
+	private Boolean doOverrideCalibration = false;
+
+	@Parameter(label = "DAPI channel")
+	private Integer dapi_channel_index = 3;
+
+	@Parameter(label = "Pixel spacing (x)", callback = "xSpacingChanged")
+	private Double xCal;
+
+	@Parameter(label = "Pixel spacing (y)", callback = "ySpacingChanged")
+	private Double yCal;
+
+	@Parameter(label = "Pixel spacing (z)")
+	private Double zCal;
+
+	@Parameter(required = false, persist = false)
+	private BufferedImage layout;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private ImagePlus fused;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private ImagePlus estimated_illumination_field;
+
+	@Parameter
+	private SCIFIO scifio;
+
+	@Parameter
+	private FormatService formatService;
+
+	@Parameter
+	private LogService logService;
+
+	private boolean is2D;
+	private long xSize;
+	private long ySize;
+	private long zSize;
+	private long nChannels;
+	private long nTimepoints;
+	private int nSeries;
+
+	private List<float[]> pixelPositions;  // holds the pixel-based positions
+	private List<String> positionNames;
+	private ArrayList<ImagePlus> images; // ArrayList required by stitching API
+	private IntervalView<FloatType> illumination_img;
+	private ArrayList<InvertibleBoundable> models;
+
+	private boolean stgRequired;
+
+	private boolean ndFileChanged = false;
+	private boolean stgFileChanged = false;
+
+	private boolean validDatasetInfo = false;
+
+	@Override
+	public void run() {
+		logService.debug("Now running...");
+
+		// Ensure valid input parameters
+		if (!doOverrideCalibration || !validDatasetInfo) updateNdFileInfo();
+		if (stgRequired && stgFile != null && stgFile.exists()) {
+			updateStgFileInfo();
+		} else if (stgRequired) {
+			autoupdateStgFileParameter();
+		}
+
+		// Start stitching process
+		if (pixelPositions.size() > 0) {
+			logService.error("Now stitching with defined positions");
+
+			is2D = (zSize > 1) ? false : true;
+
+			if (nSeries == 1) {
+				// get single stack, split into ImageCollectionElements, stitch online
+				// parameters: imp(Stack), positions
+				try {
+					ImagePlus[] imps = BF.openImagePlus(ndFile.getAbsolutePath());
+
+					Duplicator d = new Duplicator();
+
+					images = new ArrayList<>();
+					for (int i = 0; i < imps[0].getNSlices(); i++) {
+						images.add(d.run(imps[0], 1, imps[0].getNChannels(), i+1, i+1, 1, imps[0].getNFrames()));
+					}
+
+				}
+				catch (FormatException exc) {
+					logService.error("Error performing a file format operation", exc);
+					return;
+				}
+				catch (IOException exc) {
+					logService.error("Error reading file", exc);
+					return;
+				}
+
+				models = StitchingUtils.computeStitching(images, pixelPositions, 2, !stitchingMode.equals(COMPUTE_NONE), saveRAM);
+
+				fused = StitchingUtils.fuseTiles(images, models, 2);
+
+				//fused.setTitle(imps[0].getTitle() + "_fused");
+				fused.setTitle("Fused");
+				Calibration cal = new Calibration();
+				cal.pixelWidth = xCal;
+				cal.pixelHeight = yCal;
+				cal.pixelDepth = zCal;
+				fused.setCalibration(cal);
+
+				// TODO close all images?
+			} else if (stitchingMode.equals(COMPUTE_VIA_MIP) || outputMode.equals(OUTPUT_MIP)) {
+				// create MIPs for all series, stitch online
+				// parameters imp[], positions
+				logService.info("Loading tiles and computing MIPs...");
+
+				// read each series, create MIP, add to list
+				try {
+					images = new ArrayList<>();
+
+					ImporterOptions options = new ImporterOptions();
+					options.setOpenAllSeries(false);
+					options.setId(ndFile.getAbsolutePath());
+					options.setSeriesOn(0, true);
+
+					for (int i = 0; i < nSeries; i++) {
+						ImagePlus img = BF.openImagePlus(options)[0];
+						if (i == 0 ){
+							illumination_img = Views.hyperSlice(ImagePlusAdapter.convertFloat(img), 2, dapi_channel_index);
+						} else {
+							LoopBuilder.setImages(illumination_img, Views.hyperSlice(ImagePlusAdapter.convertFloat(img), 2, dapi_channel_index)).forEachPixel((s, t) -> s.setReal( s.getRealFloat() + t.getRealFloat() ) );
+						}
+						images.add(createMIP(img, ZProjector.MAX_METHOD));
+						options.setSeriesOn(i, false);
+						options.setSeriesOn(i + 1, true);
+					}
+				}
+				catch (IOException exc) {
+					logService.error("Error reading file", exc);
+					return;
+				}
+				catch (FormatException exc) {
+					logService.error("Error performing a file format operation", exc);
+					return;
+				}
+
+				try{
+					final float n_tiles = (float) images.size();
+					LoopBuilder.setImages(illumination_img).forEachPixel(s -> s.setReal(s.getRealFloat() / n_tiles));
+					final Img<FloatType> fitted_illumination_field = getIlluminationField(illumination_img, dapi_channel_index);
+					estimated_illumination_field = ImageJFunctions.wrap(fitted_illumination_field, "Estimated Illumination Field");
+
+
+					logService.info("Correcting illumination...");
+					final FloatType min = new FloatType();
+					final FloatType max = new FloatType();
+					ComputeMinMax.computeMinMax(fitted_illumination_field, min, max);
+					for (ImagePlus mip : images) {
+						IntervalView<RealType> dapi = (IntervalView<RealType>) Views.hyperSlice((ImgPlus<?>)ImagePlusAdapter.wrapImgPlus(mip), 2, dapi_channel_index);
+						LoopBuilder.setImages(dapi, fitted_illumination_field).forEachPixel(
+								(dapi_pixel, illumination_field_pixel) -> {
+									dapi_pixel.setReal(dapi_pixel.getRealFloat() / illumination_field_pixel.getRealFloat() * max.getRealDouble());
+								}
+						);
+
+					}
+				} catch (Exception exc) {
+					logService.error("Could not fit Gaussian.", exc);
+					return;
+				}
+
+				logService.info("Stitching MIPs...");
+				models = StitchingUtils.computeStitching(images, pixelPositions, 2, stitchingMode.equals(COMPUTE_NONE) ? false : true, saveRAM);
+
+				// case: via MIP: go on with full dataset
+				// load all full series into imps[]
+				// case: MIP output: fuse
+
+				fused = StitchingUtils.fuseTiles(images, models, 2);
+
+				// TODO set title and calibration
+
+			} else { // stitch with TileConfiguration.txt file
+				//String tileConfigPath = writeTileConfiguration(ndFile, pixelPositions, is2D);
+
+				// stitchClassical(tileConfigPath);
+				try {
+					// load all series into imps[]
+					ImporterOptions options = new ImporterOptions();
+					options.setOpenAllSeries(true);
+					options.setId(ndFile.getAbsolutePath());
+					ImagePlus[] imps = BF.openImagePlus(options);
+
+					images = new ArrayList<>();
+					images.addAll(Arrays.asList(imps));
+					// computeStitching
+					models = StitchingUtils.computeStitching(images, pixelPositions, is2D ? 2 : 3, stitchingMode.equals(COMPUTE_NONE) ? false : true, saveRAM);
+					// fuseTiles
+					fused = StitchingUtils.fuseTiles(images, models, is2D ? 2 : 3);
+				} catch (FormatException exc) {
+					logService.error("Error performing a file format operation", exc);
+					return;
+				} catch (IOException exc) {
+					logService.error("Error reading file", exc);
+					return;
+				}
+			}
+			// TODO consolidate StitchingUtils calls to here (using is2D)
+		} else {
+			logService.error("Initial tile positions cannot be determined.");
+			// TODO offer possibility of stitching unknown positions ?
+			return;
+		}
+
+		// cases:
+		// 1.a) stg == null => get rows/cols from nd file
+		// 1.b) nPositions > 0 => get position list
+
+		// 2.a) zSize == 1 && nTimepoints == 1 => 2D stack stitching (imp[])
+		// 2.b) MIP ? => create MIPs, the 2D stitching (imp[])
+
+		// 1) - write TileConfiguration to disk, start Grid/Collection Stitching
+		//    - read imp[] array, start stitching via API (when 2d multipos, or MIP)
+		// 2) - do stitching
+
+		// if (nSeries == 1 && zSize == nPositions) => 2D stitching
+
+		// FIXME Add functionality here
+		// Write TileConfiguration.txt from stg
+		// if compute and viaMIP: generate MIP in memory
+		// Start stitching by calling to imp[] array
+		/*
+		 * Use cases:
+		 * - Multi-region tile stitching using fmi-faim/visiview-scripts
+		 * - Tile acquisition with fixed overlap and grid (rows/cols)
+		 *
+		 * Modalities:
+		 * - Single-channel/Multi-channel
+		 * - Compute overlap on MIP
+		 * - Fuse MIP/full dataset
+		 */
+
+	}
+
+	@Nullable
+	private Img<FloatType> getIlluminationField(final IntervalView<FloatType> tile_mips, final int dapi_channel_index) {
+
+		final ImagePlus mip_stack = ImageJFunctions.wrap(Views.moveAxis(Views.addDimension(tile_mips, 0, 0), 3, 2), "tile_mip_stack");
+
+		final ImagePlus illumination_field = createMIP(mip_stack, ZProjector.MAX_METHOD);
+
+		final Localizable center_point = new Point(new long[]{illumination_field.getProcessor().getWidth() / 2,
+				illumination_field.getProcessor().getHeight() / 2});
+
+
+		logService.info("Fitting Gaussian to estimate illumination field...");
+		final Gaussian gaussian = new Gaussian();
+		final PeakFitter fitter = new PeakFitter(ImagePlusAdapter.wrap(illumination_field), Arrays.asList(center_point),
+				new LevenbergMarquardtSolver(), gaussian, new MLGaussianEstimator(illumination_field.getProcessor().getWidth()/3.0, 2));
+
+		fitter.checkInput();
+		fitter.process();
+
+		double[] gaussian_params = (double[]) fitter.getResult().get(center_point);
+		logService.info("Fitted Gaussian parameters:");
+		logService.info(" - X position: " +  String.format("%.2f", gaussian_params[0]));
+		logService.info(" - Y position: " + String.format("%.2f", gaussian_params[1]));
+		logService.info(" - Amplitude : " + String.format("%.2f", gaussian_params[2]));
+		logService.info(" - Sigma     : " + String.format("%.2f", 1. / Math.sqrt(2. * gaussian_params[3])));
+
+
+		final Img<FloatType> fitted_illumination_field = ImagePlusAdapter.convertFloat(illumination_field.duplicate());
+		final double[] pos = new double[2];
+		LoopBuilder.setImages(Intervals.positions(fitted_illumination_field), fitted_illumination_field).forEachPixel(
+				(position, pixel) -> {
+					position.localize(pos);
+					pixel.setReal(gaussian.val(pos, gaussian_params));
+				}
+		);
+		return fitted_illumination_field;
+	}
+
+
+	private ImagePlus createMIP(final ImagePlus imp, final int method) {
+		ZProjector zp = new ZProjector(imp);
+		zp.setMethod(method);
+		zp.setStopSlice(imp.getNSlices());
+		zp.doHyperStackProjection(false);
+		imp.close();
+		return zp.getProjection();
+	}
+
+	@SuppressWarnings("unused")
+	private void initializeDialog() {
+		layout = new BufferedImage(LAYOUT_WIDTH, LAYOUT_HEIGHT,
+			BufferedImage.TYPE_INT_RGB);
+	}
+
+	@SuppressWarnings("unused")
+	private void ndFileChanged() {
+		ndFileChanged = true;
+		updateNdFileInfo();
+		if (stgRequired && !stgFileChanged) autoupdateStgFileParameter();
+	}
+
+	@SuppressWarnings("unused")
+	private void stgFileChanged() {
+		stgFileChanged = true;
+		if (!ndFileChanged) autoupdateNdFileParameter();
+		updateStgFileInfo();
+	}
+
+	@SuppressWarnings("unused")
+	private void xSpacingChanged() {
+		yCal = xCal;
+		ySpacingChanged();
+	}
+
+	private void ySpacingChanged() {
+		doOverrideCalibration = true;
+		updateStgFileInfo();
+	}
+
+	private void autoupdateStgFileParameter() {
+		if (ndFile == null || !ndFile.exists()) {
+			ndMessage = "<html><p style=\"color:red\">Not a valid nd file.</p></html>";
+			return;
+		}
+		stgFile = VisiviewUtils.getMatchingStgForNd(ndFile);
+		if (stgFile == null) {
+			stgMessage =
+				"<html><p style=\"color:red\">No matching stg file found.</p></html>";
+			return;
+		}
+		stgMessage =
+			"<html><p style=\"color:green\">The stg file path was updated automatically.</p></html>";
+		updateStgFileInfo();
+	}
+
+	private void autoupdateNdFileParameter() {
+		if (stgFile == null || !stgFile.exists()) {
+			stgMessage = "<html><p style=\"color:red\">Not a valid stg file.</p></html>";
+			return;
+		}
+		ndFile = VisiviewUtils.getMatchingNdForStg(stgFile);
+		if (ndFile == null) {
+			ndMessage = "<html><p style=\"color:red\">No matching nd file found.</p></html>";
+			return;
+		}
+		ndMessage =
+			"<html><p style=\"color:green\">The nd file path was updated automatically.</p></html>";
+		updateNdFileInfo();
+	}
+
+	private void updateNdFileInfo() {
+		if (ndFile == null) return;
+		validDatasetInfo = false;
+		ndMessage = "parsing nd file..."; // TODO update dialog on separate thread?
+		// TODO use scifio.initialize() and scifio.translate() with OMEMetadata here to get series names
+
+		IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
+		try (ImageReader reader = new ImageReader()) {
+			reader.setMetadataStore(omeMeta);
+			reader.setId(ndFile.getAbsolutePath());
+		}
+		catch (FormatException exc) {
+			logService.debug("No compatible format", exc);
+			ndMessage = "No compatible format";
+		}
+		catch (IOException exc) {
+			logService.debug("Error parsing nd file", exc);
+			ndMessage = "Error parsing nd file";
+		}
+		nSeries = omeMeta.getImageCount();
+		xSize = omeMeta.getPixelsSizeX(0).getValue();
+		ySize = omeMeta.getPixelsSizeY(0).getValue();
+		zSize = omeMeta.getPixelsSizeZ(0).getValue();
+		nChannels = omeMeta.getPixelsSizeC(0).getValue();
+		nTimepoints = omeMeta.getPixelsSizeT(0).getValue();
+
+		xCal = (Double) omeMeta.getPixelsPhysicalSizeX(0).value();
+		yCal = (Double) omeMeta.getPixelsPhysicalSizeY(0).value();
+		if (zSize > 1 && nSeries > 1 && omeMeta.getPixelsPhysicalSizeZ(0) != null)
+			zCal = (Double) omeMeta.getPixelsPhysicalSizeZ(0).value();
+
+		positionNames = new ArrayList<>();
+		for (int i = 0; i < nSeries; i++) {
+			String currentPositionName = omeMeta.getImageName(i);
+			positionNames.add(currentPositionName);
+			logService.debug("Position " + i + ": " + currentPositionName);
+		}
+
+		stgRequired = !VisiviewUtils.positionsMatchGridPattern(positionNames);
+
+		if (!stgRequired) {
+			logService.debug("Position names match Row#_Col# pattern");
+			pixelPositions = VisiviewUtils.positionsFromNames(positionNames, xSize, ySize);
+
+			StitchingUtils.drawPositions(layout, pixelPositions, xSize, ySize);
+			stgMessage =
+				"<html><font style=\"color:green\">No stage position file required.</font></html>";
+		}
+
+		ndMessage = "<html>This dataset contains <font style=\"color:green\">" +
+				nSeries + "</font> series.</html>";
+		validDatasetInfo = true;
+		
+		/* SCIFIO version 2
+		try {
+			Metadata metadata = scifio.initializer().parseMetadata(ndFile.getAbsolutePath());
+			OMEMetadata omeMeta = new OMEMetadata(getContext());
+			scifio.translator().translate(metadata, omeMeta, true);
+
+			OMEXMLMetadata omeRoot = omeMeta.getRoot();
+
+			nSeries = omeRoot.getImageCount();
+
+			// get size and calibration from *first* series only
+			xSize = omeRoot.getPixelsSizeX(0).getValue();
+			ySize = omeRoot.getPixelsSizeY(0).getValue();
+			zSize = omeRoot.getPixelsSizeZ(0).getValue();
+			nChannels = omeRoot.getChannelCount(0);
+			//nTimepoints = omeRoot.getTimestampAnnotationCount(); // correct?
+			xCal = (Double) omeRoot.getPixelsPhysicalSizeX(0).value();
+			yCal = (Double) omeRoot.getPixelsPhysicalSizeY(0).value();
+			zCal = (Double) omeRoot.getPixelsPhysicalSizeZ(0).value();
+
+			//omeRoot.getImageName(0); // FIX ME get series names, populate gridPositions if applicable
+			logService.error(omeMeta.get(0).getName());
+			logService.error(metadata.get(0).getName());
+
+			positionNames = new ArrayList<>();
+			for (int i = 0; i< nSeries; i++) {
+				positionNames.add(omeRoot.getImageName(i));
+				logService.error("Position " + i + ": " + omeRoot.getImageName(i));
+			}
+
+			gridPositions = new ArrayList<>();
+			if (positionNames.get(0).startsWith("Row")) {
+				logService.error("starts with 'Row'");
+			}
+
+			ndMessage = "<html>This dataset contains <font style=\"color:green\">" +
+					nSeries + "</font> series.</html>";
+				validDatasetInfo = true;
+		}
+		catch (IOException exc) {
+			logService.debug("Error parsing nd file", exc);
+			ndMessage = "Error parsing nd file";
+		}
+		catch (FormatException exc) {
+			logService.debug("No compatible format", exc);
+			ndMessage = "No compatible format";
+		}
+		*/
+
+		/* SCIFIO version 1
+		try {
+			Format format = formatService.getFormat(ndFile.getAbsolutePath());
+			Metadata metadata = format.createParser().parse(ndFile);
+			nSeries = metadata.getImageCount();
+			ImageMetadata imageMetadata = metadata.get(0);
+
+			xSize = imageMetadata.getAxisLength(Axes.X);
+			ySize = imageMetadata.getAxisLength(Axes.Y);
+			zSize = imageMetadata.getAxisLength(Axes.Z);
+			nChannels = imageMetadata.getAxisLength(Axes.CHANNEL);
+			nTimepoints = imageMetadata.getAxisLength(Axes.TIME);
+
+			xCal = imageMetadata.getAxis(Axes.X).averageScale(0, 1);
+			yCal = imageMetadata.getAxis(Axes.Y).averageScale(0, 1);
+			zCal = imageMetadata.getAxis(Axes.Z).averageScale(0, 1);
+
+			// List<CalibratedAxis> axes = imageMetadata.getAxes();
+			ndMessage = "<html>This dataset contains <font style=\"color:green\">" +
+				nSeries + "</font> series.</html>";
+			validDatasetInfo = true;
+		}
+		catch (FormatException exc) {
+			logService.debug("No compatible format", exc);
+			ndMessage = "No compatible format";
+		}
+		catch (IOException exc) {
+			logService.debug("Error parsing nd file", exc);
+			ndMessage = "Error parsing nd file";
+		}
+		*/
+	}
+
+	private void updateStgFileInfo() {
+		try {
+			pixelPositions = VisiviewUtils.positionsFromStgFile(stgFile, xCal, yCal);
+			StitchingUtils.drawPositions(layout, pixelPositions, xSize, ySize);
+		}
+		catch (IOException exc) {
+			stgMessage = "Error parsing stg file";
+			logService.debug("Error parsing stg file", exc);
+		}
+	}
+
+	private String writeTileConfiguration(File file,
+		ArrayList<float[]> positions, boolean is2d)
+	{
+		// TODO write TileConfiguration.txt file (using Stitching API?)
+		File tileConfigFile = new File(file.getParentFile(), file.getName() + "_TileConfiguration.txt");
+		ArrayList<String> lines = new ArrayList<>();
+
+		// Header
+
+
+		// Positions
+
+
+		try {
+			Files.write(tileConfigFile.toPath(), lines, Charset.forName("UTF-8"));
+		}
+		catch (IOException exc) {
+			// TODO Auto-generated catch block
+			exc.printStackTrace();
+		}
+
+		return tileConfigFile.getAbsolutePath();
+	}
+
+}

--- a/src/main/java/ch/fmi/stitching/visiview/UIConstants.java
+++ b/src/main/java/ch/fmi/stitching/visiview/UIConstants.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/main/java/ch/fmi/stitching/visiview/VisiviewUtils.java
+++ b/src/main/java/ch/fmi/stitching/visiview/VisiviewUtils.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 package ch.fmi.stitching.visiview;

--- a/src/main/java/ch/fmi/widget/BufferedImageWidget.java
+++ b/src/main/java/ch/fmi/widget/BufferedImageWidget.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 package ch.fmi.widget;

--- a/src/main/java/ch/fmi/widget/SwingBufferedImageWidget.java
+++ b/src/main/java/ch/fmi/widget/SwingBufferedImageWidget.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/test/java/ch/fmi/visiview/Main.java
+++ b/src/test/java/ch/fmi/visiview/Main.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 

--- a/src/test/java/ch/fmi/visiview/VisiviewUtilsTest.java
+++ b/src/test/java/ch/fmi/visiview/VisiviewUtilsTest.java
@@ -2,29 +2,22 @@
  * #%L
  * ImageJ utilities and commands for stitching various datasets
  * %%
- * Copyright (C) 2019 - 2020 Friedrich Miescher Institute for Biomedical
+ * Copyright (C) 2019 - 2021 Friedrich Miescher Institute for Biomedical
  * 			Research, Basel
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 package ch.fmi.visiview;


### PR DESCRIPTION
Add a new command for MIP stitching with illumination field correction on DAPI. The illumination field is estimated by fitting a 2D Gaussian to the MIP of the 3D average of all tiles. The Gaussian is fitted with the peak-fitter from imglib2-algorithm-gpl.

* Add new dependency: imglib2-algorithm-gpl
* Switch license from BSD2 to GPL2